### PR TITLE
Add farewell endpoints to the API

### DIFF
--- a/farewells.json
+++ b/farewells.json
@@ -1,0 +1,19 @@
+[
+  { "language": "english", "farewell": "Goodbye, World!" },
+  { "language": "british", "farewell": "Goodbye, World! Cheerio!" },
+  { "language": "french", "farewell": "Au revoir, Monde !" },
+  { "language": "italian", "farewell": "Ciao, Mondo!" },
+  { "language": "spanish", "farewell": "¡Adiós, Mundo!" },
+  { "language": "german", "farewell": "Auf Wiedersehen, Welt!" },
+  { "language": "mandarin", "farewell": "再见，世界！" },
+  { "language": "hindi", "farewell": "अलविदा दुनिया!" },
+  { "language": "arabic", "farewell": "وداعا أيها العالم!" },
+  { "language": "bengali", "farewell": "বিদায় পৃথিবী!" },
+  { "language": "russian", "farewell": "До свидания, мир!" },
+  { "language": "portuguese", "farewell": "Tchau, Mundo!" },
+  { "language": "urdu", "farewell": "الوداع، دنیا!" },
+  { "language": "indonesian", "farewell": "Selamat tinggal Dunia!" },
+  { "language": "japanese", "farewell": "さようなら世界！" },
+  { "language": "marathi", "farewell": "निरोप जग!" },
+  { "language": "telugu", "farewell": "వీడ్కోలు ప్రపంచం!" }
+]

--- a/main.go
+++ b/main.go
@@ -16,9 +16,17 @@ import (
 //go:embed greetings.json
 var greetingsJson []byte
 
+//go:embed farewells.json
+var farewellsJson []byte
+
 type Greeting struct {
 	Language string `json:"language"`
 	Greeting string `json:"greeting"`
+}
+
+type Farewell struct {
+	Language string `json:"language"`
+	Farewell string `json:"farewell"`
 }
 
 func main() {
@@ -28,6 +36,14 @@ func main() {
 		fmt.Printf("error loading greetings: %s\n", err)
 		os.Exit(1)
 	}
+	
+	var farewells []*Farewell
+	err = json.Unmarshal(farewellsJson, &farewells)
+	if err != nil {
+		fmt.Printf("error loading farewells: %s\n", err)
+		os.Exit(1)
+	}
+	
 	router := mux.NewRouter()
 
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +53,7 @@ func main() {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
-		_, err = w.Write([]byte(FormatResponse(greeting)))
+		_, err = w.Write([]byte(FormatGreetingResponse(greeting)))
 		if err != nil {
 			panic(err)
 		}
@@ -51,7 +67,34 @@ func main() {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
-		_, err = w.Write([]byte(FormatResponse(greeting)))
+		_, err = w.Write([]byte(FormatGreetingResponse(greeting)))
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("GET")
+
+	router.HandleFunc("/farewell", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("got /farewell request from %s\n", r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		farewell, err := SelectFarewell(farewells, "random")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		_, err = w.Write([]byte(FormatFarewellResponse(farewell)))
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("GET")
+
+	router.HandleFunc("/farewell/{language}", func(w http.ResponseWriter, r *http.Request) {
+		language := mux.Vars(r)["language"]
+		fmt.Printf("got /farewell/{language} request from %s\n", r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		farewell, err := SelectFarewell(farewells, language)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		_, err = w.Write([]byte(FormatFarewellResponse(farewell)))
 		if err != nil {
 			panic(err)
 		}
@@ -74,8 +117,12 @@ func main() {
 	}
 }
 
-func FormatResponse(greeting *Greeting) string {
+func FormatGreetingResponse(greeting *Greeting) string {
 	return fmt.Sprintf("{\"greeting\":\"%s\"}", greeting.Greeting)
+}
+
+func FormatFarewellResponse(farewell *Farewell) string {
+	return fmt.Sprintf("{\"farewell\":\"%s\"}", farewell.Farewell)
 }
 
 func SelectGreeting(greetings []*Greeting, language string) (*Greeting, error) {
@@ -96,4 +143,24 @@ func SelectGreeting(greetings []*Greeting, language string) (*Greeting, error) {
 	}
 
 	return nil, fmt.Errorf("no greeting found for language '%s'", language)
+}
+
+func SelectFarewell(farewells []*Farewell, language string) (*Farewell, error) {
+	if len(farewells) == 0 {
+		return nil, errors.New("no farewells available")
+	}
+
+	if language == "random" {
+		// Get random item from farewells slice
+		randomIndex := rand.Intn(len(farewells))
+		return farewells[randomIndex], nil
+	}
+
+	for _, farewell := range farewells {
+		if farewell.Language == language {
+			return farewell, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no farewell found for language '%s'", language)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -40,12 +40,53 @@ func TestSelectGreeting(t *testing.T) {
 	assert.Error(t, err, "no greeting found for language ''")
 }
 
-func TestFormatResponse(t *testing.T) {
+func TestSelectFarewell(t *testing.T) {
+	var farewells []*Farewell
+	err := json.Unmarshal(farewellsJson, &farewells)
+	if err != nil {
+		fmt.Printf("error loading farewells: %s\n", err)
+		os.Exit(1)
+	}
+
+	english := &Farewell{
+		Farewell: "Goodbye, World!",
+		Language: "english",
+	}
+
+	// Test with a language
+	f, err := SelectFarewell(farewells, "english")
+	assert.NilError(t, err)
+	assert.Equal(t, *english, *f)
+
+	// Test random
+	_, err = SelectFarewell(farewells, "random")
+	assert.NilError(t, err)
+
+	// Test invalid language
+	_, err = SelectFarewell(farewells, "foooooo")
+	assert.Error(t, err, "no farewell found for language 'foooooo'")
+
+	// Test empty language
+	_, err = SelectFarewell(farewells, "")
+	assert.Error(t, err, "no farewell found for language ''")
+}
+
+func TestFormatGreetingResponse(t *testing.T) {
 	g := &Greeting{
 		Greeting: "Hello, World!",
 		Language: "english",
 	}
 
-	formatted := FormatResponse(g)
+	formatted := FormatGreetingResponse(g)
 	assert.Equal(t, "{\"greeting\":\"Hello, World!\"}", formatted)
+}
+
+func TestFormatFarewellResponse(t *testing.T) {
+	f := &Farewell{
+		Farewell: "Goodbye, World!",
+		Language: "english",
+	}
+
+	formatted := FormatFarewellResponse(f)
+	assert.Equal(t, "{\"farewell\":\"Goodbye, World!\"}", formatted)
 }


### PR DESCRIPTION
Add API endpoints for farewells in multiple languages, mirroring the existing greeting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b55e47d-ce81-4783-a89b-b251284e43d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b55e47d-ce81-4783-a89b-b251284e43d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

