### PR TITLE
Add farewell endpoints to API

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,10 +1,10 @@
 # Greetings API Documentation
 
-Welcome to the Greetings API! This simple service allows you to retrieve greetings in various languages.
+Welcome to the Greetings API! This simple service allows you to retrieve greetings and farewells in various languages.
 
 ## Using the REST API
 
-The Greetings API provides two main endpoints for retrieving greetings:
+The Greetings API provides endpoints for retrieving both greetings and farewells:
 
 ### Get a Random Greeting
 
@@ -39,29 +39,62 @@ GET http://locahost:8080/french
 }
 ```
 
+### Get a Random Farewell
+
+```
+GET http://locahost:8080/farewell
+```
+
+**Example Response:**
+```json
+{
+  "farewell": "Goodbye, World!"
+}
+```
+
+### Get a Farewell in a Specific Language
+
+```
+GET http://locahost:8080/farewell/{language}
+```
+
+Replace `{language}` with one of the supported language codes.
+
+**Example Request:**
+```
+GET http://locahost:8080/farewell/french
+```
+
+**Example Response:**
+```json
+{
+  "farewell": "Au revoir, Monde !"
+}
+```
+
 ## Supported Languages
 
-The API currently supports the following languages:
+The API currently supports the following languages for both greetings and farewells:
 
-| Language Code | Greeting |
-|---------------|----------|
-| english       | Hello, World! |
-| british       | Hello, World! Cheers! |
-| french        | Bonjour, Monde ! |
-| italian       | Ciao, Mondo! |
-| spanish       | ¡Hola, Mundo! |
-| german        | Hallo, Welt! |
-| mandarin      | 你好，世界！ |
-| hindi         | नमस्ते दुनिया! |
-| arabic        | مرحبا بالعالم! |
-| bengali       | ওহে বিশ্ব! |
-| russian       | Привет, мир! |
-| portuguese    | Olá, Mundo! |
-| urdu          | ہیلو، دنیا! |
-| indonesian    | Halo Dunia! |
-| japanese      | こんにちは世界！ |
-| marathi       | नमस्कार जग! |
-| telugu        | హలో ప్రపంచం! |
+| Language Code | Greeting | Farewell |
+|---------------|----------|----------|
+| english       | Hello, World! | Goodbye, World! |
+| british       | Hello, World! Cheers! | Goodbye, World! Cheerio! |
+| french        | Bonjour, Monde ! | Au revoir, Monde ! |
+| italian       | Ciao, Mondo! | Ciao, Mondo! |
+| spanish       | ¡Hola, Mundo! | ¡Adiós, Mundo! |
+| german        | Hallo, Welt! | Auf Wiedersehen, Welt! |
+| mandarin      | 你好，世界！ | 再见，世界！ |
+| hindi         | नमस्ते दुनिया! | अलविदा दुनिया! |
+| arabic        | مرحبا بالعالم! | وداعا بالعالم! |
+| bengali       | ওহে বিশ্ব! | বিদায় বিশ্ব! |
+| russian       | Привет, мир! | До свидания, мир! |
+| portuguese    | Olá, Mundo! | Tchau, Mundo! |
+| urdu          | ہیلو، دنیا! | الوداع، دنیا! |
+| indonesian    | Halo Dunia! | Selamat tinggal Dunia! |
+| japanese      | こんにちは世界！ | さようなら世界！ |
+| marathi       | नमस्कार जग! | निरोप जग! |
+| telugu        | హలో ప్రపంచం! | వీడ్కోలు ప్రపంచం! |
 
 ## Using the Greetings Website
 
@@ -80,10 +113,17 @@ Currently, there are no rate limits on the API usage, but please be respectful o
 
 If you request a language that doesn't exist, the API will return an appropriate error message with a 400 status code.
 
-Example error response:
+Example error response for greetings:
 ```json
 {
   "error": "no greeting found for language 'klingon'"
+}
+```
+
+Example error response for farewells:
+```json
+{
+  "error": "no farewell found for language 'klingon'"
 }
 ```
 

--- a/farewells.json
+++ b/farewells.json
@@ -1,0 +1,19 @@
+[
+  { "language": "english", "farewell": "Goodbye, World!" },
+  { "language": "british", "farewell": "Goodbye, World! Cheerio!" },
+  { "language": "french", "farewell": "Au revoir, Monde !" },
+  { "language": "italian", "farewell": "Ciao, Mondo!" },
+  { "language": "spanish", "farewell": "¡Adiós, Mundo!" },
+  { "language": "german", "farewell": "Auf Wiedersehen, Welt!" },
+  { "language": "mandarin", "farewell": "再见，世界！" },
+  { "language": "hindi", "farewell": "अलविदा दुनिया!" },
+  { "language": "arabic", "farewell": "وداعا بالعالم!" },
+  { "language": "bengali", "farewell": "বিদায় বিশ্ব!" },
+  { "language": "russian", "farewell": "До свидания, мир!" },
+  { "language": "portuguese", "farewell": "Tchau, Mundo!" },
+  { "language": "urdu", "farewell": "الوداع، دنیا!" },
+  { "language": "indonesian", "farewell": "Selamat tinggal Dunia!" },
+  { "language": "japanese", "farewell": "さようなら世界！" },
+  { "language": "marathi", "farewell": "निरोप जग!" },
+  { "language": "telugu", "farewell": "వీడ్కోలు ప్రపంచం!" }
+]

--- a/main.go
+++ b/main.go
@@ -16,9 +16,17 @@ import (
 //go:embed greetings.json
 var greetingsJson []byte
 
+//go:embed farewells.json
+var farewellsJson []byte
+
 type Greeting struct {
 	Language string `json:"language"`
 	Greeting string `json:"greeting"`
+}
+
+type Farewell struct {
+	Language string `json:"language"`
+	Farewell string `json:"farewell"`
 }
 
 func main() {
@@ -28,8 +36,17 @@ func main() {
 		fmt.Printf("error loading greetings: %s\n", err)
 		os.Exit(1)
 	}
+
+	var farewells []*Farewell
+	err = json.Unmarshal(farewellsJson, &farewells)
+	if err != nil {
+		fmt.Printf("error loading farewells: %s\n", err)
+		os.Exit(1)
+	}
+
 	router := mux.NewRouter()
 
+	// Greeting endpoints
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("got / request from %s\n", r.RemoteAddr)
 		w.Header().Set("Content-Type", "application/json")
@@ -37,7 +54,7 @@ func main() {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
-		_, err = w.Write([]byte(FormatResponse(greeting)))
+		_, err = w.Write([]byte(FormatGreetingResponse(greeting)))
 		if err != nil {
 			panic(err)
 		}
@@ -51,7 +68,35 @@ func main() {
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
-		_, err = w.Write([]byte(FormatResponse(greeting)))
+		_, err = w.Write([]byte(FormatGreetingResponse(greeting)))
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("GET")
+
+	// Farewell endpoints
+	router.HandleFunc("/farewell", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("got /farewell request from %s\n", r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		farewell, err := SelectFarewell(farewells, "random")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		_, err = w.Write([]byte(FormatFarewellResponse(farewell)))
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("GET")
+
+	router.HandleFunc("/farewell/{language}", func(w http.ResponseWriter, r *http.Request) {
+		language := mux.Vars(r)["language"]
+		fmt.Printf("got /farewell/{language} request from %s\n", r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		farewell, err := SelectFarewell(farewells, language)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		_, err = w.Write([]byte(FormatFarewellResponse(farewell)))
 		if err != nil {
 			panic(err)
 		}
@@ -74,8 +119,12 @@ func main() {
 	}
 }
 
-func FormatResponse(greeting *Greeting) string {
+func FormatGreetingResponse(greeting *Greeting) string {
 	return fmt.Sprintf("{\"greeting\":\"%s\"}", greeting.Greeting)
+}
+
+func FormatFarewellResponse(farewell *Farewell) string {
+	return fmt.Sprintf("{\"farewell\":\"%s\"}", farewell.Farewell)
 }
 
 func SelectGreeting(greetings []*Greeting, language string) (*Greeting, error) {
@@ -96,4 +145,24 @@ func SelectGreeting(greetings []*Greeting, language string) (*Greeting, error) {
 	}
 
 	return nil, fmt.Errorf("no greeting found for language '%s'", language)
+}
+
+func SelectFarewell(farewells []*Farewell, language string) (*Farewell, error) {
+	if len(farewells) == 0 {
+		return nil, errors.New("no farewells available")
+	}
+
+	if language == "random" {
+		// Get random item from farewells slice
+		randomIndex := rand.Intn(len(farewells))
+		return farewells[randomIndex], nil
+	}
+
+	for _, farewell := range farewells {
+		if farewell.Language == language {
+			return farewell, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no farewell found for language '%s'", language)
 }


### PR DESCRIPTION
Add farewell endpoints to the API, mirroring the existing greeting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-60a2506b-5e4c-4ac6-8a54-82c0625f9b03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60a2506b-5e4c-4ac6-8a54-82c0625f9b03">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

