### PR TITLE
Add farewell endpoints to API

### DIFF
--- a/farewells.json
+++ b/farewells.json
@@ -1,0 +1,19 @@
+[
+  { "language": "english", "farewell": "Goodbye, World!" },
+  { "language": "british", "farewell": "Goodbye, World! Cheerio!" },
+  { "language": "french", "farewell": "Au revoir, Monde !" },
+  { "language": "italian", "farewell": "Arrivederci, Mondo!" },
+  { "language": "spanish", "farewell": "¡Adiós, Mundo!" },
+  { "language": "german", "farewell": "Auf Wiedersehen, Welt!" },
+  { "language": "mandarin", "farewell": "再见，世界！" },
+  { "language": "hindi", "farewell": "अलविदा दुनिया!" },
+  { "language": "arabic", "farewell": "وداعا أيها العالم!" },
+  { "language": "bengali", "farewell": "বিদায় পৃথিবী!" },
+  { "language": "russian", "farewell": "До свидания, мир!" },
+  { "language": "portuguese", "farewell": "Tchau, Mundo!" },
+  { "language": "urdu", "farewell": "خدا حافظ، دنیا!" },
+  { "language": "indonesian", "farewell": "Selamat tinggal, Dunia!" },
+  { "language": "japanese", "farewell": "さようなら世界！" },
+  { "language": "marathi", "farewell": "निरोप जग!" },
+  { "language": "telugu", "farewell": "వీడ్కోలు ప్రపంచం!" }
+]

--- a/main.go
+++ b/main.go
@@ -16,9 +16,17 @@ import (
 //go:embed greetings.json
 var greetingsJson []byte
 
+//go:embed farewells.json
+var farewellsJson []byte
+
 type Greeting struct {
 	Language string `json:"language"`
 	Greeting string `json:"greeting"`
+}
+
+type Farewell struct {
+	Language string `json:"language"`
+	Farewell string `json:"farewell"`
 }
 
 func main() {
@@ -28,8 +36,17 @@ func main() {
 		fmt.Printf("error loading greetings: %s\n", err)
 		os.Exit(1)
 	}
+
+	var farewells []*Farewell
+	err = json.Unmarshal(farewellsJson, &farewells)
+	if err != nil {
+		fmt.Printf("error loading farewells: %s\n", err)
+		os.Exit(1)
+	}
+
 	router := mux.NewRouter()
 
+	// Greeting endpoints
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Printf("got / request from %s\n", r.RemoteAddr)
 		w.Header().Set("Content-Type", "application/json")
@@ -38,6 +55,34 @@ func main() {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		_, err = w.Write([]byte(FormatResponse(greeting)))
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("GET")
+
+	// Farewell endpoints - these need to be registered before /{language} to avoid conflicts
+	router.HandleFunc("/farewells", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Printf("got /farewells request from %s\n", r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		farewell, err := SelectFarewell(farewells, "random")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		_, err = w.Write([]byte(FormatFarewellResponse(farewell)))
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("GET")
+
+	router.HandleFunc("/farewells/{language}", func(w http.ResponseWriter, r *http.Request) {
+		language := mux.Vars(r)["language"]
+		fmt.Printf("got /farewells/{language} request from %s\n", r.RemoteAddr)
+		w.Header().Set("Content-Type", "application/json")
+		farewell, err := SelectFarewell(farewells, language)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
+		_, err = w.Write([]byte(FormatFarewellResponse(farewell)))
 		if err != nil {
 			panic(err)
 		}
@@ -78,6 +123,10 @@ func FormatResponse(greeting *Greeting) string {
 	return fmt.Sprintf("{\"greeting\":\"%s\"}", greeting.Greeting)
 }
 
+func FormatFarewellResponse(farewell *Farewell) string {
+	return fmt.Sprintf("{\"farewell\":\"%s\"}", farewell.Farewell)
+}
+
 func SelectGreeting(greetings []*Greeting, language string) (*Greeting, error) {
 	if len(greetings) == 0 {
 		return nil, errors.New("no greetings available")
@@ -96,4 +145,24 @@ func SelectGreeting(greetings []*Greeting, language string) (*Greeting, error) {
 	}
 
 	return nil, fmt.Errorf("no greeting found for language '%s'", language)
+}
+
+func SelectFarewell(farewells []*Farewell, language string) (*Farewell, error) {
+	if len(farewells) == 0 {
+		return nil, errors.New("no farewells available")
+	}
+
+	if language == "random" {
+		// Get random item from farewells slice
+		randomIndex := rand.Intn(len(farewells))
+		return farewells[randomIndex], nil
+	}
+
+	for _, farewell := range farewells {
+		if farewell.Language == language {
+			return farewell, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no farewell found for language '%s'", language)
 }


### PR DESCRIPTION
Add multi-language farewell endpoints to the API to complement existing greeting functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ac283ed-9267-46b3-aa75-0a2485ba4d0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ac283ed-9267-46b3-aa75-0a2485ba4d0f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

